### PR TITLE
chore: upgrade gh actions cache from v2 to v3

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
Version v2 of the [actions/cache](https://github.com/actions/toolkit/blob/main/packages/cache/README.md) has been deprecated as of March 1st, 2025. See [this](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down) blog post. Upgraded to [v3](https://github.com/marketplace/actions/cache#v3) (not v4) as this still supports Node 16. Changes in v3/4 releases are [fully backward compatible](https://github.com/marketplace/actions/cache#%EF%B8%8F-important-changes).